### PR TITLE
use a plain serializer to enable pystac Classificiation in BaseModel

### DIFF
--- a/stac_model/examples.py
+++ b/stac_model/examples.py
@@ -3,7 +3,7 @@ import json
 import shapely
 from stac_model.schema import (
     Asset,
-    ClassObject,
+    MLMClassification,
     InputArray,
     MLModelExtension,
     MLModelProperties,
@@ -13,7 +13,6 @@ from stac_model.schema import (
     Runtime,
     Statistics,
 )
-
 
 def eurosat_resnet():
     input_array = InputArray(
@@ -106,9 +105,10 @@ def eurosat_resnet():
         "SeaLake": 9,
     }
     class_objects = [
-        ClassObject(value=class_map[class_name], name=class_name)
+        MLMClassification.create(value=class_map[class_name], description=class_name, name=class_name)
         for class_name in class_map
     ]
+
     output = ModelOutput(
         task="classification",
         classification_classes=class_objects,

--- a/stac_model/output.py
+++ b/stac_model/output.py
@@ -1,7 +1,13 @@
 from enum import Enum
-from typing import List, Optional, Union
-
-from pydantic import BaseModel, Field
+from typing import List, Optional, Union, Any, Dict
+from pystac.extensions.classification import Classification
+from pydantic import (
+    BaseModel,
+    Field,
+    ConfigDict,
+    PlainSerializer,
+)
+from typing_extensions import Annotated
 
 
 class TaskEnum(str, Enum):
@@ -26,16 +32,13 @@ class ResultArray(BaseModel):
         pattern="^(uint8|uint16|uint32|uint64|int8|int16|int32|int64|float16|float32|float64)$",
     )
 
-class ClassObject(BaseModel):
-    value: int
-    name: str
-    description: Optional[str] = None
-    title: Optional[str] = None
-    color_hint: Optional[str] = None
-    nodata: Optional[bool] = False
+MLMClassification = Annotated[Classification,
+                             PlainSerializer(lambda x: x.to_dict(), return_type=Dict[str, Any], when_used='json')]
 
 class ModelOutput(BaseModel):
     task: TaskEnum
     result_array: Optional[List[ResultArray]] = None
-    classification_classes: Optional[List[ClassObject]] = None
+    classification_classes: Optional[List[MLMClassification]] = None
     post_processing_function: Optional[str] = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/stac_model/schema.py
+++ b/stac_model/schema.py
@@ -25,7 +25,7 @@ from pystac.extensions.base import (
 )
 
 from .input import Band, InputArray, ModelInput, Statistics
-from .output import ClassObject, ModelOutput, ResultArray, TaskEnum
+from .output import MLMClassification, ModelOutput, ResultArray, TaskEnum
 from .runtime import Asset, Container, Runtime
 
 T = TypeVar(
@@ -240,7 +240,7 @@ __all__ = [
     "Band",
     "Statistics",
     "ModelOutput",
-    "ClassObject",
+    "MLMClassification",
     "Asset",
     "ResultArray",
     "Runtime",


### PR DESCRIPTION
Tests pass for serializing the pystac item and reading in the item with pystac when using the annotated Classification class from pystac in the output BaseModel. If this approach looks good I can do the same for Statistics and Band @fmigneault

